### PR TITLE
ci: add conventional commits linter

### DIFF
--- a/.github/workflows/git.yml
+++ b/.github/workflows/git.yml
@@ -1,0 +1,15 @@
+---
+name: Conventional Commits
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    name: Conventional Commits
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: webiny/action-conventional-commits@v1.1.0


### PR DESCRIPTION
What
---
Add conventional commits linter

Why
---
All commits should follow https://www.conventionalcommits.org/en/v1.0.0-beta.2/