### PR TITLE
ci: add markdown lint

### DIFF
--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -1,0 +1,12 @@
+---
+name: Markdown
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: markdownlint-cli
+    uses: nosborn/github-action-markdown-cli@v3.2.0
+    with:
+      files: .
+      dot: true


### PR DESCRIPTION
What
---
Add markdown lint from https://github.com/marketplace/actions/markdownlint-cli

Why
---
Linting all markdown early so that we have consistent markdown